### PR TITLE
Make `publicPath` current folder

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = {
 
   output: {
     path: buildPath,
-    publicPath: '/',
+    publicPath: './',
     filename: '[name].[contenthash].js',
     assetModuleFilename: 'images/[name][ext]',
   },


### PR DESCRIPTION
Make `publicPath` current folder, to support context-path for the
deployment. This will be useful if we will deploy it on something
else than `/`.